### PR TITLE
Fix lint warnings

### DIFF
--- a/inlet/metadata/provider/ovs/config.go
+++ b/inlet/metadata/provider/ovs/config.go
@@ -1,3 +1,4 @@
+// Package ovs implements a metadata provider backed by OVSDB.
 package ovs
 
 import "akvorado/inlet/metadata/provider"

--- a/inlet/metadata/provider/ovs/root.go
+++ b/inlet/metadata/provider/ovs/root.go
@@ -1,3 +1,4 @@
+// Package ovs implements a metadata provider backed by OVSDB.
 package ovs
 
 import (
@@ -11,7 +12,7 @@ import (
 )
 
 // newClient is used to create a new OVSDB client. It is overridden in tests.
-var newClient = func(cfg Configuration) (ovsclient.Client, error) {
+var newClient = func(_ Configuration) (ovsclient.Client, error) {
 	return ovsclient.NewOVSDBClient()
 }
 

--- a/inlet/metadata/provider/ovs/root_test.go
+++ b/inlet/metadata/provider/ovs/root_test.go
@@ -17,16 +17,15 @@ type mockClient struct {
 	ch   chan ovsclient.TableUpdates
 }
 
-func (m *mockClient) MonitorAll(ctx context.Context, tables []string) (<-chan ovsclient.TableUpdates, error) {
+func (m *mockClient) MonitorAll(_ context.Context, _ []string) (<-chan ovsclient.TableUpdates, error) {
 	return m.ch, nil
 }
-func (m *mockClient) List(ctx context.Context, table string, out interface{}) error { return nil }
-func (m *mockClient) Close()                                                        {}
-
+func (m *mockClient) List(_ context.Context, _ string, _ interface{}) error { return nil }
+func (m *mockClient) Close()                                                {}
 func TestQueryAndWatch(t *testing.T) {
 	updates := make(chan ovsclient.TableUpdates, 1)
 	mc := &mockClient{ch: updates}
-	newClient = func(cfg Configuration) (ovsclient.Client, error) { return mc, nil }
+	newClient = func(_ Configuration) (ovsclient.Client, error) { return mc, nil }
 	r := reporter.NewMock(t)
 	var got []provider.Update
 	p, err := Configuration{}.New(r, func(u provider.Update) { got = append(got, u) })

--- a/libovsdbstub/client/client.go
+++ b/libovsdbstub/client/client.go
@@ -1,3 +1,4 @@
+// Package client defines a minimal libovsdb client interface used in tests.
 package client
 
 import "context"
@@ -23,6 +24,7 @@ type Client interface {
 	Close()
 }
 
+// Option represents a configuration option for NewOVSDBClient.
 type Option interface{}
 
 // NewOVSDBClient is a stub constructor used in tests.


### PR DESCRIPTION
## Summary
- add package comments for `ovs` metadata provider and test stub
- document the `Option` type in `libovsdbstub`
- rename unused parameters in `ovs` tests and implementation

## Testing
- `go test ./...` *(fails: pattern data/frontend: no matching files)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7eca6e8832a915c5ae9e3d00f49